### PR TITLE
Remove --install from fish-shell postinst

### DIFF
--- a/fish-shell/Makefile
+++ b/fish-shell/Makefile
@@ -59,8 +59,6 @@ define Package/fish-shell/postinst
 #!/bin/sh
 
 grep -q 'fish' /opt/etc/shells || echo "/opt/bin/fish" >> /opt/etc/shells
-
-[ -d "/opt/share/fish" ] || fish --install -vn > /dev/null 2>&1
 endef
 
 $(eval $(call BuildPackage,fish-shell))


### PR DESCRIPTION
The --install option was [removed in 4.1.0](https://fishshell.com/docs/current/relnotes.html#id26) and now results in an error when trying to install fish. The details on [self-installing builds](https://fishshell.com/docs/current/relnotes.html#changelog-4-1-embedded) make it sound like it's no longer necessary to run any command at all, but I could be mistaken.

See also https://github.com/fish-shell/fish-shell/pull/11143.

Currently package installation succeeds but exits in an error due to the postinst script using an option that no longer exists.

```
> sudo /opt/bin/opkg install fish
Package fish-shell (4.5.0-1) installed in root is up to date.
Configuring fish-shell.
Collected errors:
 * pkg_run_script: package "fish-shell" postinst script returned status 1.
 * opkg_configure: fish-shell.postinst returned
```

