### PR TITLE
Fix building packages with CONFIG_AUTOREMOVE

### DIFF
--- a/rustc-dev/cargo.mk
+++ b/rustc-dev/cargo.mk
@@ -5,6 +5,10 @@
 rust_mk_path:=$(dir $(lastword $(MAKEFILE_LIST)))
 include $(rust_mk_path)rust.mk
 
+ifneq ($(findstring /deps-dev/,$(CURDIR)),)
+  override CONFIG_AUTOREMOVE=
+endif
+
 CARGO_ARGS += -Z unstable-options
 USE_CARGO_COMPILE ?= 1
 USE_CARGO_UPDATE ?= 0


### PR DESCRIPTION
This PR fixes building some of packages with enabled `CONFIG_AUTOREMOVE` (disables `CONFIG_AUTOREMOVE` for several packages where need to store cache in `build_dir` folder because this cache required for code generation / for dependent packages)